### PR TITLE
Update project documentation to reflect CUDA kernel implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Flash-Kernels-v2 is a lean playground for experimenting with CUDA GPU kernels. It provides hand-optimized GPU kernels with performance benchmarking and correctness testing for common deep learning operations.
+
+## Key Commands
+
+### Setup
+```bash
+python -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Testing
+```bash
+# Run all tests (FP32 + BF16)
+pytest -q evals
+
+# Run specific kernel test
+pytest evals/test_layer_norm.py
+```
+
+### Benchmarking
+```bash
+# Quick benchmark for a specific kernel
+bash benchmarks/run_layer_norm_sol.sh
+
+# Manual benchmark with visualization
+python benchmarks/scripts/benchmark_layer_norm.py --overwrite
+python benchmarks/benchmark_visualizer.py --kernel-name layer_norm --metric-name speed --display
+```
+
+## Architecture
+
+### Core Components
+
+1. **Kernel Implementations** (`new_kernels/`)
+   - Each kernel has its own subdirectory: `layer_norm/`, `softmax/`, `diagonal_matmul/`, `fused_linear_rowsum/`
+   - Each contains main implementation and `Functional/` subdirectory with functional interface
+   - Kernels are written in CUDA C++ and compiled via PyTorch's cpp_extension.load_inline
+
+2. **Testing** (`evals/`)
+   - PyTest-based correctness tests comparing CUDA implementations against PyTorch references
+   - Uses `utils.assert_verbose_allclose()` for strict tolerance checking
+   - Tests run on both FP32 and BF16 (when hardware supports it)
+
+3. **Benchmarking** (`benchmarks/`)
+   - `scripts/` contains benchmark scripts for each kernel
+   - Results stored in `data/` as CSV files
+   - Visualizations generated in `visualizations/`
+   - Supports custom (CUDA) and torch (PyTorch) providers
+   - Uses Triton's benchmarking utilities (triton.testing.do_bench) for timing
+
+### Key Implementation Patterns
+
+- Kernels defined as CUDA C++ source strings (`_CUDA_SRC`)
+- Compiled on-the-fly using `torch.utils.cpp_extension.load_inline`
+- Forward and backward passes implemented separately
+- Functional interfaces wrap the low-level kernels for easier use
+- Device detection handles CUDA/XPU automatically via `utils.device_utils`
+
+### Development Notes
+
+- GPU Requirements: CUDA 11.8+, Compute Capability ≥ 7.0
+- BF16 requires Ampere or newer (CC ≥ 8.0)
+- Full benchmark suite needs ≥40 GB VRAM
+- No build system - kernels compile on-the-fly via PyTorch's JIT compilation
+- Speed-of-light overlays show theoretical memory bandwidth limits on performance graphs

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Flash-Kernels v2 – Quick Reference
 
-A lean playground for experimenting with **Triton** GPU kernels.
+A lean playground for experimenting with **CUDA** GPU kernels.
 
 Directory highlights
 1. `benchmarks/` – micro-benchmarks + visualisations
-2. `new_kernels/` – hand-tuned Triton ops (LayerNorm, Softmax, …)
+2. `new_kernels/` – hand-tuned CUDA kernels (LayerNorm, Softmax, …)
 3. `evals/` – PyTest correctness & regression suite
 4. `agents/` – LLM pipeline that auto-writes kernels for KernelBench
 
@@ -12,7 +12,7 @@ Directory highlights
 ## 1 · Installation
 ```bash
 python -m venv venv && source venv/bin/activate
-pip install -r requirements.txt      # Triton ≥2,<3 + plotting + agent deps
+pip install -r requirements.txt      # Dependencies including Triton (for benchmarking), PyTorch, plotting libs
 ```
 GPU prerequisites
 * CUDA 11.8+ drivers
@@ -23,7 +23,7 @@ GPU prerequisites
 ```bash
 pytest -q evals       # FP32 + BF16 when supported
 ```
-Tests compare the Triton kernels against the PyTorch reference with strict
+Tests compare the CUDA kernels against the PyTorch reference with strict
 `assert_verbose_allclose` tolerances.
 
 ---

--- a/benchmarks/run_layer_norm_sol.sh
+++ b/benchmarks/run_layer_norm_sol.sh
@@ -3,7 +3,7 @@
 # run_layer_norm_speed.sh – end-to-end LayerNorm speed benchmark + SoL overlay
 # -----------------------------------------------------------------------------
 # 1. Runs benchmarks/scripts/benchmark_layer_norm.py for the forward path on
-#    both the custom Triton kernel and PyTorch reference implementation.
+#    both the custom CUDA kernel and PyTorch reference implementation.
 # 2. Generates an annotated plot with a speed-of-light (memory-bound lower-bound)
 #    line using the helper in scripts/plot_layer_norm_sol.py.
 # 3. Stores artefacts under benchmarks/output/ for easy retrieval.

--- a/benchmarks/run_softmax_sol.sh
+++ b/benchmarks/run_softmax_sol.sh
@@ -3,7 +3,7 @@
 # run_softmax_sol.sh – end-to-end Softmax speed benchmark + SoL overlay
 # -----------------------------------------------------------------------------
 # 1. Runs benchmarks/scripts/benchmark_softmax.py for the forward path on
-#    both the custom Triton kernel and PyTorch reference implementation.
+#    both the custom CUDA kernel and PyTorch reference implementation.
 # 2. Generates an annotated plot with a speed-of-light (memory-bound lower-bound)
 #    line using the helper in scripts/plot_softmax_sol.py.
 # 3. Stores artefacts under benchmarks/output/ for easy retrieval.

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -14,7 +14,6 @@ from typing import Callable, List, Optional, Union, Dict, Any
 
 import torch
 import triton
-import triton.language as tl
 
 QUANTILES = [0.5, 0.2, 0.8]
 
@@ -101,7 +100,7 @@ def calculate_settings(n):
     BLOCK_SIZE = triton.next_power_of_2(n)
     if BLOCK_SIZE > MAX_FUSED_SIZE:
         raise RuntimeError(
-            f"Cannot launch Triton kernel since n = {n} exceeds the recommended Triton blocksize = {MAX_FUSED_SIZE}."
+            f"Cannot launch kernel since n = {n} exceeds the recommended blocksize = {MAX_FUSED_SIZE}."
         )
 
     num_warps = 4


### PR DESCRIPTION
- Created CLAUDE.md with accurate project overview for Claude Code instances
- Updated all references from "Triton kernels" to "CUDA kernels" throughout
- Clarified that Triton is only used for benchmarking utilities
- Removed unused import 'triton.language as tl' from utils.py
- Fixed misleading error messages and comments

The project uses CUDA C++ kernels compiled via PyTorch's cpp_extension.load_inline, not Triton kernels. Triton library is only used for its benchmarking utilities.
