### PR TITLE
Update project documentation to reflect CUDA kernel implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Flash-Kernels v2 – Quick Reference
 
-A lean playground for experimenting with **Triton** GPU kernels.
+A lean playground for experimenting with **CUDA** GPU kernels.
 
 Directory highlights
 1. `benchmarks/` – micro-benchmarks + visualisations
-2. `new_kernels/` – hand-tuned Triton ops (LayerNorm, Softmax, …)
+2. `new_kernels/` – hand-tuned CUDA kernels (LayerNorm, Softmax, …)
 3. `evals/` – PyTest correctness & regression suite
 4. `agents/` – LLM pipeline that auto-writes kernels for KernelBench
 
@@ -12,7 +12,7 @@ Directory highlights
 ## 1 · Installation
 ```bash
 python -m venv venv && source venv/bin/activate
-pip install -r requirements.txt      # Triton ≥2,<3 + plotting + agent deps
+pip install -r requirements.txt      # Dependencies including Triton (for benchmarking), PyTorch, plotting libs
 ```
 GPU prerequisites
 * CUDA 11.8+ drivers
@@ -23,7 +23,7 @@ GPU prerequisites
 ```bash
 pytest -q evals       # FP32 + BF16 when supported
 ```
-Tests compare the Triton kernels against the PyTorch reference with strict
+Tests compare the CUDA kernels against the PyTorch reference with strict
 `assert_verbose_allclose` tolerances.
 
 ---

--- a/benchmarks/run_layer_norm_sol.sh
+++ b/benchmarks/run_layer_norm_sol.sh
@@ -3,7 +3,7 @@
 # run_layer_norm_speed.sh – end-to-end LayerNorm speed benchmark + SoL overlay
 # -----------------------------------------------------------------------------
 # 1. Runs benchmarks/scripts/benchmark_layer_norm.py for the forward path on
-#    both the custom Triton kernel and PyTorch reference implementation.
+#    both the custom CUDA kernel and PyTorch reference implementation.
 # 2. Generates an annotated plot with a speed-of-light (memory-bound lower-bound)
 #    line using the helper in scripts/plot_layer_norm_sol.py.
 # 3. Stores artefacts under benchmarks/output/ for easy retrieval.

--- a/benchmarks/run_softmax_sol.sh
+++ b/benchmarks/run_softmax_sol.sh
@@ -3,7 +3,7 @@
 # run_softmax_sol.sh – end-to-end Softmax speed benchmark + SoL overlay
 # -----------------------------------------------------------------------------
 # 1. Runs benchmarks/scripts/benchmark_softmax.py for the forward path on
-#    both the custom Triton kernel and PyTorch reference implementation.
+#    both the custom CUDA kernel and PyTorch reference implementation.
 # 2. Generates an annotated plot with a speed-of-light (memory-bound lower-bound)
 #    line using the helper in scripts/plot_softmax_sol.py.
 # 3. Stores artefacts under benchmarks/output/ for easy retrieval.

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -14,7 +14,6 @@ from typing import Callable, List, Optional, Union, Dict, Any
 
 import torch
 import triton
-import triton.language as tl
 
 QUANTILES = [0.5, 0.2, 0.8]
 
@@ -101,7 +100,7 @@ def calculate_settings(n):
     BLOCK_SIZE = triton.next_power_of_2(n)
     if BLOCK_SIZE > MAX_FUSED_SIZE:
         raise RuntimeError(
-            f"Cannot launch Triton kernel since n = {n} exceeds the recommended Triton blocksize = {MAX_FUSED_SIZE}."
+            f"Cannot launch kernel since n = {n} exceeds the recommended blocksize = {MAX_FUSED_SIZE}."
         )
 
     num_warps = 4


### PR DESCRIPTION
- Update references from 'Triton kernels' to 'CUDA kernels'
- Clarify Triton usage only for benchmarking utilities
- Remove unused import triton.language as tl
- Fix misleading error messages and comments